### PR TITLE
Add optional node load balancing and "circuit breaker" node selection

### DIFF
--- a/lighthive/client.py
+++ b/lighthive/client.py
@@ -50,7 +50,8 @@ class Client:
         self.load_balance_nodes = load_balance_nodes
         self.circuit_breaker = circuit_breaker
         self.circuit_breaker_ttl = circuit_breaker_ttl
-        self.circuit_breaker_cache = TTLCache(maxsize=len(self._raw_node_list), ttl=circuit_breaker_ttl)
+        # The max size of the node ban cache is num_nodes - 1 to ensure there will always be one node available
+        self.circuit_breaker_cache = TTLCache(maxsize=len(self._raw_node_list)-1, ttl=circuit_breaker_ttl)
         if automatic_node_selection:
             self._sort_nodes_by_response_time()
         self.next_node()

--- a/lighthive/client.py
+++ b/lighthive/client.py
@@ -51,7 +51,7 @@ class Client:
         self.load_balance_nodes = load_balance_nodes
         self.circuit_breaker = circuit_breaker
         self.circuit_breaker_ttl = circuit_breaker_ttl
-        self.circuit_breaker_cache = TTLCache(maxsize=len(nodes), ttl=circuit_breaker_ttl)
+        self.circuit_breaker_cache = TTLCache(maxsize=len(self._raw_node_list), ttl=circuit_breaker_ttl)
         self.circuit_breaker_cache['https://hived.emre.sh'] = True
         if automatic_node_selection:
             self._sort_nodes_by_response_time()

--- a/lighthive/client.py
+++ b/lighthive/client.py
@@ -26,11 +26,11 @@ DEFAULT_NODES = [
     "https://techcoderx.com",
 ]
 
+backoff_mode = backoff.expo
+backoff_max_tries = 5
+
 
 class Client:
-
-    backoff_mode = backoff.expo
-    backoff_max_tries = 5
 
     def __init__(self, nodes=None, keys=None, connect_timeout=3,
                  read_timeout=30, loglevel=logging.ERROR, chain=None, automatic_node_selection=False,
@@ -147,13 +147,13 @@ class Client:
             return
 
         try:
+            if self.load_balance_nodes:
+                self.next_node()
             response = self._send_request(
                 self.current_node,
                 request_data,
                 (self.connect_timeout, self.read_timeout),
             )
-            if self.load_balance_nodes:
-                self.next_node()
         except requests.exceptions.RequestException as e:
             self.logger.error(e)
             num_retries = kwargs.get("num_retries", 1)

--- a/lighthive/node_picker.py
+++ b/lighthive/node_picker.py
@@ -70,10 +70,18 @@ async def compare_nodes(nodes, logger):
 
 
 def sort_nodes_by_response_time(nodes, logger):
+    local_loop = False
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        local_loop = True
     start_time = time.time()
-    loop = asyncio.get_event_loop()
     nodes = loop.run_until_complete(compare_nodes(nodes, logger))
     total_time_elapsed = time.time() - start_time
     logger.info(f"Automatic node selection took  {total_time_elapsed:.2f} seconds.")
+
+    if local_loop:
+        loop.close()
 
     return nodes

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='lighthive',
-    version='0.4.0a0',
+    version='0.4.0a1',
     packages=find_packages('.'),
     url='http://github.com/emre/lighthive',
     license='MIT',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='lighthive',
-    version='0.4.0',
+    version='0.4.0a0',
     packages=find_packages('.'),
     url='http://github.com/emre/lighthive',
     license='MIT',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='lighthive',
-    version='0.3.3',
+    version='0.4.0',
     packages=find_packages('.'),
     url='http://github.com/emre/lighthive',
     license='MIT',

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     author='emre yilmaz',
     author_email='mail@emreyilmaz.me',
     description='A light python client to interact with the HIVE blockchain',
-    install_requires=["requests", "backoff", "ecdsa", "dateutils", "httpx"],
+    install_requires=["requests", "backoff~=2.0", "ecdsa", "dateutils", "httpx", "cachetools"],
     extras_require={
         'dev': [
             'requests_mock',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='lighthive',
-    version='0.4.0a1',
+    version='0.4.0a2',
     packages=find_packages('.'),
     url='http://github.com/emre/lighthive',
     license='MIT',


### PR DESCRIPTION
This adds two new features to the lighthive `Client`:

1. Opt-in round robin load balancing to change the node in use on every request
2. A hybrid "[circuit breaker](https://martinfowler.com/bliki/CircuitBreaker.html)"* where nodes that fail after the request backoff exceeds its given parameters will be added to a "grey" list which prevents it from being used in node selection for a configurable amount of seconds (defaulting to 1 hour).  This helps prevent issues when a given node is temporarily having problems.
The circuit breaker is implemented as an expiring dictionary cache from `cachetools`.  This is not a traditional Circuit Breaker implementation because we have many "circuits" to choose from for selection.  A traditional Circuit Breaker would simply error out as opposed to maintaining a grey list.

Additionally, this PR does a couple of extras that were nice to have or make integration easier:
* Changed from `itertools.cycle` to `collections.deque`, utilizing `deque.rotate()` to select new nodes.  This made it easier to accomplish load balancing and a grey list.
* Made the backoff mode and max_tries configurable on the object level via constructor params and a closure.

Unrelated to other changes, this PR also fixes `sort_nodes_by_response_time` to attempt using an existing asyncio loop if one is running.  Particularly important for integration into other asyncio applications.

These changes are currently running in production by @daveajones for @Podcastindex-org's podping watcher, and they have increased stability of said watcher considerably.